### PR TITLE
Avoid variable conflicting

### DIFF
--- a/circleci-provision-scripts/ruby.sh
+++ b/circleci-provision-scripts/ruby.sh
@@ -38,16 +38,17 @@ EOF
 
 
 function install_ruby_version() {
-    RUBY_VERSION=$1
+    INSTALL_RUBY_VERSION=$1
     RUBYGEMS_MAJOR_RUBY_VERSION=${2:-2}
     (cat <<'EOF'
 
 set -e
 
-echo Installing Ruby version: $RUBY_VERSION
+echo Installing Ruby version: $INSTALL_RUBY_VERSION
+
 source ~/.circlerc
 
-rvm use $RUBY_VERSION
+rvm use $INSTALL_RUBY_VERSION
 
 # TODO: Avoid this for jruby
 rvm rubygems latest-${RUBYGEMS_MAJOR_RUBY_VERSION}
@@ -57,7 +58,7 @@ rvm @global do gem install bundler -v 1.9.5
 rvm @global do gem install rspec
 
 EOF
-    ) | as_user RUBY_VERSION=$RUBY_VERSION RUBYGEMS_MAJOR_RUBY_VERSION=$RUBYGEMS_MAJOR_RUBY_VERSION bash
+    ) | as_user INSTALL_RUBY_VERSION=$INSTALL_RUBY_VERSION RUBYGEMS_MAJOR_RUBY_VERSION=$RUBYGEMS_MAJOR_RUBY_VERSION bash
 }
 
 function install_ruby() {


### PR DESCRIPTION
$RUBY_VERSION got conflicted with probably the same name of env var used by rvm.

```
+ sudo -H -u ubuntu bash
+ install_ruby_version 2.2.2
+ RUBY_VERSION=2.2.2
+ RUBYGEMS_MAJOR_RUBY_VERSION=2
+ cat
+ as_user RUBY_VERSION=2.2.2 RUBYGEMS_MAJOR_RUBY_VERSION=2 bash
+ sudo -H -u ubuntu RUBY_VERSION=2.2.2 RUBYGEMS_MAJOR_RUBY_VERSION=2 bash
Installing Ruby version: 2.2.2
Using /home/ubuntu/.rvm/gems/ruby-2.2.1
ruby-2.2.1 - #downloading rubygems-2.5.1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  458k  100  458k    0     0  10.0M      0 --:--:-- --:--:-- --:--:-- 10.1M
No checksum for downloaded archive, recording checksum in user configuration.
ruby-2.2.1 - #extracting rubygems-2.5.1....
ruby-2.2.1 - #removing old rubygems.........
$LANG was empty, setting up LANG=en_US.utf8, if it fails again try setting LANG to something sane and try again.
ruby-2.2.1 - #installing rubygems-2.5.1..................
Successfully installed bundler-1.9.5
1 gem installed
Successfully installed rspec-support-3.4.1
Successfully installed rspec-core-3.4.1
Successfully installed diff-lcs-1.2.5
Successfully installed rspec-expectations-3.4.0
Successfully installed rspec-mocks-3.4.0
Successfully installed rspec-3.4.0
```